### PR TITLE
Address String to Object bug fix and Map View Annotation fix

### DIFF
--- a/InstaPark/Base.lproj/Main.storyboard
+++ b/InstaPark/Base.lproj/Main.storyboard
@@ -65,7 +65,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jbx-F9-Sil">
-                                <rect key="frame" x="87" y="158" width="240" height="30"/>
+                                <rect key="frame" x="87" y="114" width="240" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="8TC-YG-d8X"/>
@@ -4703,9 +4703,9 @@
         </designable>
     </designables>
     <inferredMetricsTieBreakers>
-        <segue reference="lZp-Rj-hWj"/>
+        <segue reference="qv6-dG-1Q7"/>
         <segue reference="WaY-RN-Vf8"/>
-        <segue reference="fHt-Y7-lI7"/>
+        <segue reference="mXm-Gb-kR6"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Arrow" width="6" height="10"/>

--- a/InstaPark/Base.lproj/Main.storyboard
+++ b/InstaPark/Base.lproj/Main.storyboard
@@ -479,16 +479,16 @@
                             <rect key="frame" x="37.666666666666657" y="72" width="249.99999999999997" height="309"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="73A-Fb-4js">
-                                    <rect key="frame" x="0.0" y="0.0" width="250" height="47.333333333333336"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="250" height="48"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome Back!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3H0-tR-UEw">
-                                            <rect key="frame" x="0.0" y="0.0" width="166.66666666666666" height="28"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="166" height="28.333333333333332"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <fontDescription key="fontDescription" name="Roboto-Bold" family="Roboto" pointSize="24"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="When are you looking to park? " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rDi-FE-aeL">
-                                            <rect key="frame" x="0.0" y="31" width="250" height="16.333333333333329"/>
+                                            <rect key="frame" x="0.0" y="31.333333333333329" width="250" height="16.666666666666671"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="250" id="6NJ-Qp-2cX"/>
                                             </constraints>
@@ -498,7 +498,7 @@
                                     </subviews>
                                 </stackView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndm-Ke-7tg">
-                                    <rect key="frame" x="0.0" y="66.333333333333343" width="250" height="85"/>
+                                    <rect key="frame" x="0.0" y="67" width="250" height="85"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="250" id="Lxh-X8-2BX"/>
                                         <constraint firstAttribute="height" constant="85" id="jDY-qc-WJe"/>
@@ -509,7 +509,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ca-za-s4A">
-                                    <rect key="frame" x="0.0" y="170.33333333333334" width="250" height="90.000000000000028"/>
+                                    <rect key="frame" x="0.0" y="171" width="250" height="90"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="250" id="TFM-NG-Jlj"/>
                                         <constraint firstAttribute="height" constant="90" id="tST-IX-7f0"/>
@@ -517,7 +517,7 @@
                                     <state key="normal" title="Button" image="monthly"/>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pJq-O5-sYt">
-                                    <rect key="frame" x="87" y="279.33333333333331" width="76" height="29.666666666666686"/>
+                                    <rect key="frame" x="88.333333333333343" y="280" width="73" height="29"/>
                                     <fontDescription key="fontDescription" name="Roboto-Italic" family="Roboto" pointSize="14"/>
                                     <state key="normal" title="Skip to map">
                                         <color key="titleColor" systemColor="systemGrayColor"/>
@@ -1344,13 +1344,13 @@
                                         <rect key="frame" x="57.666666666666671" y="322" width="232.66666666666663" height="19.666666666666686"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jmf-tp-CTT">
-                                                <rect key="frame" x="0.0" y="0.0" width="37.333333333333336" height="19.666666666666668"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="38.666666666666664" height="19.666666666666668"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="End" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hSH-hq-g7X">
-                                                <rect key="frame" x="204.33333333333331" y="0.0" width="28.333333333333343" height="19.666666666666668"/>
+                                                <rect key="frame" x="205.66666666666663" y="0.0" width="27" height="19.666666666666668"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -2430,10 +2430,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="yam-6X-bww">
-                                <rect key="frame" x="44.666666666666657" y="154" width="325" height="375"/>
+                                <rect key="frame" x="44.666666666666657" y="153.99999999999997" width="325" height="375.33333333333326"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jty-H6-c3a">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="65"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="65.333333333333329"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WELCOME BACK!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pht-lU-dL7">
                                                 <rect key="frame" x="0.0" y="0.0" width="186.33333333333334" height="36"/>
@@ -2443,7 +2443,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="When are you looking to park? " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dli-Oh-RKC">
-                                                <rect key="frame" x="0.0" y="44" width="325" height="21"/>
+                                                <rect key="frame" x="0.0" y="44" width="325" height="21.333333333333329"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="325" id="s6H-ol-oeX"/>
                                                 </constraints>
@@ -2454,7 +2454,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FRE-Ui-OXM">
-                                        <rect key="frame" x="0.0" y="115" width="325" height="105"/>
+                                        <rect key="frame" x="0.0" y="115.33333333333331" width="325" height="105"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="52" translatesAutoresizingMaskIntoConstraints="NO" id="4ds-Me-wgk">
                                                 <rect key="frame" x="163" y="38" width="143.33333333333337" height="30"/>
@@ -2513,7 +2513,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZdL-Ds-lGs">
-                                        <rect key="frame" x="0.0" y="270" width="325" height="105"/>
+                                        <rect key="frame" x="0.0" y="270.33333333333331" width="325" height="105"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="59G-O8-WAr">
                                                 <rect key="frame" x="160" y="38" width="142.33333333333337" height="30"/>
@@ -2573,7 +2573,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="60f-en-ksd">
-                                <rect key="frame" x="194" y="555.66666666666663" width="26" height="22"/>
+                                <rect key="frame" x="194" y="556" width="26" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="Kes-tg-n5v"/>
                                     <constraint firstAttribute="width" constant="26" id="xNO-td-Nqv"/>
@@ -2583,7 +2583,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SRn-DR-w5R">
-                                <rect key="frame" x="44.666666666666657" y="609.66666666666663" width="325" height="42"/>
+                                <rect key="frame" x="44.666666666666657" y="610" width="325" height="42"/>
                                 <color key="backgroundColor" red="0.93725490196078431" green="0.85490196078431369" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="4zT-es-0SL"/>
@@ -2809,16 +2809,16 @@
                             </connections>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="0ao-vQ-bai">
-                            <rect key="frame" x="102.33333333333331" y="21" width="120.66666666666669" height="21"/>
+                            <rect key="frame" x="101" y="21" width="123.33333333333331" height="21.333333333333329"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VwW-eZ-leU">
-                                    <rect key="frame" x="0.0" y="0.0" width="91.666666666666671" height="21"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="94.333333333333329" height="21.333333333333332"/>
                                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="18"/>
                                     <color key="textColor" red="0.5607843137254902" green="0.0" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Info-button" translatesAutoresizingMaskIntoConstraints="NO" id="JFE-tI-7Ge">
-                                    <rect key="frame" x="102.66666666666667" y="0.0" width="18" height="21"/>
+                                    <rect key="frame" x="105.33333333333334" y="0.0" width="18" height="21.333333333333332"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="18" id="hGj-bv-Dq2"/>
                                     </constraints>
@@ -2826,7 +2826,7 @@
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a0O-ss-OH2">
-                            <rect key="frame" x="35" y="124.00000000000001" width="255" height="28.666666666666671"/>
+                            <rect key="frame" x="35" y="125.00000000000001" width="255" height="28.666666666666671"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="255" id="g1P-sb-K5H"/>
                             </constraints>
@@ -2856,19 +2856,19 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ex: renting a spot from 2:00 PM to 5:00 PM" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Gh-1M-qRA">
-                            <rect key="frame" x="48.999999999999986" y="90" width="231.66666666666663" height="14"/>
+                            <rect key="frame" x="49" y="90.666666666666671" width="228" height="14.333333333333329"/>
                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                             <color key="textColor" red="0.42745098039215684" green="0.42745098039215684" blue="0.42745098039215684" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ex: renting a spot from January to June" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b3g-Ob-te1">
-                            <rect key="frame" x="49.000000000000014" y="157.66666666666666" width="210.33333333333337" height="14"/>
+                            <rect key="frame" x="48.999999999999986" y="158.66666666666666" width="208.66666666666663" height="14.333333333333343"/>
                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                             <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.42745098040000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hourly parking means other buyers will rent your parking spot for hours at a time." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mQu-3c-uI6">
-                            <rect key="frame" x="35" y="57" width="255" height="28"/>
+                            <rect key="frame" x="35" y="57.333333333333336" width="255" height="28.333333333333336"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="255" id="5XE-Ht-60f"/>
                             </constraints>
@@ -3631,13 +3631,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NAME YOUR PRICE!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gRt-pe-6xT">
-                                <rect key="frame" x="35" y="113" width="282.33333333333331" height="35"/>
+                                <rect key="frame" x="35" y="113" width="167.33333333333334" height="36"/>
                                 <fontDescription key="fontDescription" name="BebasNeue-Regular" family="Bebas Neue" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SYk-b2-HQQ">
-                                <rect key="frame" x="35" y="173" width="325" height="33.666666666666657"/>
+                                <rect key="frame" x="35" y="174" width="325" height="33.666666666666657"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="325" id="Pu9-Fk-vK0"/>
                                 </constraints>
@@ -3651,16 +3651,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="8PO-rN-bXb">
-                                <rect key="frame" x="104.66666666666669" y="381.66666666666669" width="205" height="42"/>
+                                <rect key="frame" x="104" y="382.66666666666669" width="206" height="42.333333333333314"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DQM-Fd-ge7">
-                                        <rect key="frame" x="0.0" y="0.0" width="20.333333333333332" height="42"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="20.333333333333332" height="42.333333333333336"/>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="36"/>
                                         <color key="textColor" red="0.50196078431372548" green="0.45490196078431372" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="9eS-oV-t7j">
-                                        <rect key="frame" x="21.333333333333329" y="5" width="60" height="37"/>
+                                        <rect key="frame" x="21.333333333333329" y="5.3333333333333144" width="60" height="37"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="XX" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3b3-X7-UWy">
                                                 <rect key="frame" x="0.0" y="0.0" width="60" height="35"/>
@@ -3686,7 +3686,7 @@
                                         </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHq-eQ-902">
-                                        <rect key="frame" x="82.333333333333329" y="15" width="10.666666666666671" height="27"/>
+                                        <rect key="frame" x="82.333333333333343" y="15.333333333333314" width="10.333333333333329" height="27"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="27" id="xJ6-JX-ZC4"/>
                                         </constraints>
@@ -3695,7 +3695,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="rF4-r8-vZ1">
-                                        <rect key="frame" x="93.999999999999986" y="5" width="60.000000000000014" height="37"/>
+                                        <rect key="frame" x="93.666666666666657" y="5.3333333333333144" width="60" height="37"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="XX" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QCj-yw-Eti">
                                                 <rect key="frame" x="0.0" y="0.0" width="60" height="35"/>
@@ -3721,7 +3721,7 @@
                                         </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" /" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cpT-jY-ZSu">
-                                        <rect key="frame" x="155" y="21" width="14.666666666666657" height="21"/>
+                                        <rect key="frame" x="154.66666666666669" y="21.333333333333314" width="16" height="21"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="21" id="6N1-iW-fVf"/>
                                         </constraints>
@@ -3730,7 +3730,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="hour" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T17-LV-1xY">
-                                        <rect key="frame" x="170.66666666666663" y="29" width="34.333333333333343" height="13"/>
+                                        <rect key="frame" x="171.66666666666669" y="29.333333333333314" width="34.333333333333343" height="13"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="13" id="V3d-d9-CAR"/>
                                         </constraints>
@@ -3777,7 +3777,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What TYPE OF PARKING IS YOUR SPOT?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N75-vj-Exg">
-                                        <rect key="frame" x="35" y="113" width="325" height="70"/>
+                                        <rect key="frame" x="35" y="113" width="325" height="72"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="325" id="lwd-ug-oue"/>
                                         </constraints>
@@ -3786,22 +3786,22 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are 4 main types of parking spots. Which can " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKO-Yl-lMl">
-                                        <rect key="frame" x="35" y="213" width="279" height="14"/>
+                                        <rect key="frame" x="35" y="215" width="275.66666666666669" height="14.333333333333343"/>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="G1Y-ZE-KlV">
-                                        <rect key="frame" x="35" y="232" width="109" height="22"/>
+                                        <rect key="frame" x="35.000000000000007" y="234.33333333333334" width="106.66666666666669" height="22.000000000000028"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="describe yours?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vkz-lg-3iR">
-                                                <rect key="frame" x="0.0" y="0.0" width="86" height="22"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="83.666666666666671" height="22"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pXf-7J-Wsc">
-                                                <rect key="frame" x="91" y="0.0" width="18" height="22"/>
+                                                <rect key="frame" x="88.666666666666671" y="0.0" width="18" height="22"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="22" id="1p2-E9-zrB"/>
                                                     <constraint firstAttribute="width" constant="18" id="9NK-0I-G4S"/>
@@ -3814,10 +3814,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CsO-Db-8y2">
-                                        <rect key="frame" x="35" y="284.66666666666669" width="287" height="26"/>
+                                        <rect key="frame" x="35" y="287" width="274" height="27"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jgt-km-dVb">
-                                                <rect key="frame" x="0.0" y="0.0" width="70" height="26"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="66" height="27"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                 <state key="normal" title="   Driveway   ">
@@ -3828,7 +3828,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YzD-Kc-oDg">
-                                                <rect key="frame" x="92" y="0.0" width="60" height="26"/>
+                                                <rect key="frame" x="88" y="0.0" width="56" height="27"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                 <state key="normal" title="   Garage   ">
@@ -3839,7 +3839,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WNf-m6-f75">
-                                                <rect key="frame" x="174" y="0.0" width="53" height="26"/>
+                                                <rect key="frame" x="166" y="0.0" width="50" height="27"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                 <state key="normal" title="   Street   ">
@@ -3850,7 +3850,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WuC-ZS-i0y">
-                                                <rect key="frame" x="249" y="0.0" width="38" height="26"/>
+                                                <rect key="frame" x="238" y="0.0" width="36" height="27"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                 <state key="normal" title="   Lot   ">
@@ -3863,13 +3863,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Any Additional features?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pzk-hX-44g">
-                                        <rect key="frame" x="35" y="435.66666666666669" width="327" height="35"/>
+                                        <rect key="frame" x="35.000000000000014" y="439" width="252.33333333333337" height="36"/>
                                         <fontDescription key="fontDescription" name="BebasNeue-Regular" family="Bebas Neue" pointSize="30"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is so buyers know as much as they can before renting. Instapark recommends adding at least 2 or more!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FFN-Ud-6WO">
-                                        <rect key="frame" x="35" y="485.66666666666669" width="350" height="28.000000000000057"/>
+                                        <rect key="frame" x="35" y="490" width="350" height="28.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="350" id="kCR-ez-API"/>
                                         </constraints>
@@ -3878,13 +3878,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="NXg-zQ-UvF">
-                                        <rect key="frame" x="35" y="553.66666666666663" width="334.66666666666669" height="93"/>
+                                        <rect key="frame" x="35" y="558.33333333333337" width="334.66666666666669" height="93"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="0qL-Ir-8QU">
-                                                <rect key="frame" x="0.0" y="0.0" width="84.666666666666671" height="93"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="85.333333333333329" height="93"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="HNj-fV-cqF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="84.666666666666671" height="12"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="85.333333333333329" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i7c-if-VO2">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -3901,7 +3901,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tandem" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2r9-AV-ffa">
-                                                                <rect key="frame" x="18" y="0.0" width="66.666666666666671" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="67.333333333333329" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -3909,7 +3909,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="txA-x9-Oc7">
-                                                        <rect key="frame" x="0.0" y="27" width="84.666666666666671" height="12"/>
+                                                        <rect key="frame" x="0.0" y="27" width="85.333333333333329" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JZx-mb-hFm">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -3926,7 +3926,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Well-lit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="thZ-0U-rDA">
-                                                                <rect key="frame" x="18" y="0.0" width="66.666666666666671" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="67.333333333333329" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -3934,7 +3934,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="7t3-cj-RDd">
-                                                        <rect key="frame" x="0.0" y="54" width="84.666666666666671" height="12"/>
+                                                        <rect key="frame" x="0.0" y="54" width="85.333333333333329" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uHe-AP-xMt">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -3951,7 +3951,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gated" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeT-mK-1OD">
-                                                                <rect key="frame" x="18" y="0.0" width="66.666666666666671" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="67.333333333333329" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -3959,7 +3959,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Vt4-TL-sA2">
-                                                        <rect key="frame" x="0.0" y="81" width="84.666666666666671" height="12"/>
+                                                        <rect key="frame" x="0.0" y="81" width="85.333333333333329" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OXc-2Q-Cn8">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -3976,7 +3976,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="24/7 Access" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2hD-Ze-doC">
-                                                                <rect key="frame" x="18" y="0.0" width="66.666666666666671" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="67.333333333333329" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -3986,10 +3986,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Aj5-6D-iPc">
-                                                <rect key="frame" x="184.66666666666663" y="0.0" width="150" height="93"/>
+                                                <rect key="frame" x="185.33333333333331" y="0.0" width="149.33333333333331" height="93"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="BS5-aL-wOZ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="12"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="149.33333333333334" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aip-VA-AOt">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -4006,7 +4006,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Security on-site" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xTL-6M-M2a">
-                                                                <rect key="frame" x="18" y="0.0" width="132" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="131.33333333333334" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -4014,7 +4014,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="6By-qc-bYh">
-                                                        <rect key="frame" x="0.0" y="27" width="150" height="12"/>
+                                                        <rect key="frame" x="0.0" y="27" width="149.33333333333334" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="63B-at-HFH">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -4031,7 +4031,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remote controlled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1AH-g8-WAU">
-                                                                <rect key="frame" x="18" y="0.0" width="132" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="131.33333333333334" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -4039,7 +4039,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="8MV-Zo-Jf9">
-                                                        <rect key="frame" x="0.0" y="54" width="150" height="12"/>
+                                                        <rect key="frame" x="0.0" y="54" width="149.33333333333334" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nmi-pn-jYN">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -4056,7 +4056,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cellular service available" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ElM-cA-DH2">
-                                                                <rect key="frame" x="18" y="0.0" width="132" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="131.33333333333334" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -4064,7 +4064,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="oKK-0B-sNW">
-                                                        <rect key="frame" x="0.0" y="81" width="150" height="12"/>
+                                                        <rect key="frame" x="0.0" y="81" width="149.33333333333334" height="12"/>
                                                         <subviews>
                                                             <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pj3-95-rGh">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -4081,7 +4081,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Covered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M9z-eE-hGz">
-                                                                <rect key="frame" x="18" y="0.0" width="132" height="12"/>
+                                                                <rect key="frame" x="18" y="0.0" width="131.33333333333334" height="12"/>
                                                                 <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -4268,13 +4268,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Any pictures to upload?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZVW-nd-tzz">
-                                <rect key="frame" x="35" y="113" width="319" height="35"/>
+                                <rect key="frame" x="35" y="113" width="241" height="36"/>
                                 <fontDescription key="fontDescription" name="BebasNeue-Regular" family="Bebas Neue" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A picture is worth a thousand words. Upload a few to give your buyers a better idea of your spot!" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="129-Aa-g3X">
-                                <rect key="frame" x="35" y="173" width="306" height="28"/>
+                                <rect key="frame" x="35" y="174" width="306" height="28.333333333333343"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="306" id="8fo-Gp-XqT"/>
                                 </constraints>
@@ -4330,13 +4330,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Any last comments?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SsP-E0-vW9">
-                                <rect key="frame" x="35" y="113" width="273.66666666666669" height="35"/>
+                                <rect key="frame" x="35.000000000000014" y="113" width="203.33333333333337" height="36"/>
                                 <fontDescription key="fontDescription" name="BebasNeue-Regular" family="Bebas Neue" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Now is your chance to put it in words! Add a short description to describe your spot." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ADx-lh-40G">
-                                <rect key="frame" x="35" y="173" width="306" height="28"/>
+                                <rect key="frame" x="35" y="174" width="306" height="28.333333333333343"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="306" id="scX-tP-U0e"/>
                                 </constraints>
@@ -4345,7 +4345,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="wUK-Nf-gBl">
-                                <rect key="frame" x="49.666666666666657" y="326" width="315" height="173.33333333333337"/>
+                                <rect key="frame" x="49.666666666666657" y="327.33333333333331" width="315" height="173.66666666666669"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="fh8-n1-NS6">
                                         <rect key="frame" x="0.0" y="0.0" width="315" height="150"/>
@@ -4365,7 +4365,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </textView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/140" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="faA-YC-2hD">
-                                        <rect key="frame" x="279" y="157" width="36" height="16.333333333333343"/>
+                                        <rect key="frame" x="277.66666666666663" y="157" width="37.333333333333314" height="16.666666666666657"/>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                         <color key="textColor" red="0.42745098039215684" green="0.42745098039215684" blue="0.42745098039215684" alpha="0.89803921568627454" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -4404,7 +4404,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Specific directions to your spot?" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lrm-3K-cs8">
-                                <rect key="frame" x="35" y="113" width="200" height="70"/>
+                                <rect key="frame" x="35" y="113" width="200" height="72"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="pXG-oK-lcO"/>
                                 </constraints>
@@ -4413,7 +4413,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If there are any specific directions or action items needed to access your spot, please leave a note below for your buyer." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dk7-cQ-uTo">
-                                <rect key="frame" x="35" y="208" width="306" height="42"/>
+                                <rect key="frame" x="35" y="210" width="306" height="42.333333333333343"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="306" id="ci5-Mv-39a"/>
                                 </constraints>
@@ -4422,7 +4422,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="DAd-mb-u5x">
-                                <rect key="frame" x="49.666666666666657" y="499.99999999999994" width="315" height="173.33333333333331"/>
+                                <rect key="frame" x="49.666666666666657" y="502.33333333333331" width="315" height="173.66666666666669"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qj8-gJ-jVh">
                                         <rect key="frame" x="0.0" y="0.0" width="315" height="150"/>
@@ -4442,7 +4442,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </textView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/140" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lk9-Lb-ofm">
-                                        <rect key="frame" x="279" y="157" width="36" height="16.333333333333343"/>
+                                        <rect key="frame" x="277.66666666666663" y="157.00000000000006" width="37.333333333333314" height="16.666666666666657"/>
                                         <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="14"/>
                                         <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.42745098040000001" alpha="0.8980392157" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -4450,10 +4450,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="3se-xE-orh">
-                                <rect key="frame" x="69.666666666666686" y="300" width="275" height="96"/>
+                                <rect key="frame" x="69.666666666666686" y="302.33333333333331" width="275" height="96.333333333333314"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recent directions:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vwl-3W-ivB">
-                                        <rect key="frame" x="0.0" y="0.0" width="275" height="14"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="275" height="14.333333333333334"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="275" id="VbE-jT-EuZ"/>
                                         </constraints>
@@ -4462,13 +4462,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="BZd-PT-HNG">
-                                        <rect key="frame" x="0.0" y="21" width="275" height="75"/>
+                                        <rect key="frame" x="0.0" y="21.333333333333371" width="275" height="75"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="8L1-vv-udC">
                                                 <rect key="frame" x="17.333333333333314" y="0.0" width="240" height="75"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="S1K-GG-iM1">
-                                                        <rect key="frame" x="0.0" y="16.666666666666686" width="240" height="42"/>
+                                                        <rect key="frame" x="0.0" y="16.333333333333318" width="240" height="42.333333333333343"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xi0-Gu-0J6">
                                                                 <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
@@ -4481,7 +4481,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="After pulling up by Ophir, turn right after the stop sign - the spot is the 2nd one on the left." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7UZ-MA-2hM">
-                                                                <rect key="frame" x="25" y="0.0" width="215" height="42"/>
+                                                                <rect key="frame" x="25" y="0.0" width="215" height="42.333333333333336"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="215" id="OkW-nu-uCh"/>
                                                                 </constraints>

--- a/InstaPark/Controllers/ListingViewControllers/ListingAddressViewController.swift
+++ b/InstaPark/Controllers/ListingViewControllers/ListingAddressViewController.swift
@@ -219,12 +219,16 @@ class ListingAddressViewController: UIViewController {
             //if there is an extra street addresss line
             if addressArray.count == 5 {
                 stateAndZip = addressArray[3].components(separatedBy: " ")
+                stateAndZip.removeAll {$0 == ""}
                 ShortTermParking.address = Address(city: addressArray[2], state: stateAndZip[0], street: addressArray[0] + ", " +  addressArray[1], zip: stateAndZip[1])
                 print(ShortTermParking.address)
                 return true
             }
             else if addressArray.count == 4 {
                 stateAndZip = addressArray[2].components(separatedBy: "  ")
+                if stateAndZip.count == 1 {
+                    stateAndZip = addressArray[2].components(separatedBy: " ")
+                }
                 ShortTermParking.address = Address(city: addressArray[1], state: stateAndZip[0], street: addressArray[0], zip: stateAndZip[1])
                 print(ShortTermParking.address)
                 return true

--- a/InstaPark/Controllers/MapViewViewController.swift
+++ b/InstaPark/Controllers/MapViewViewController.swift
@@ -575,9 +575,9 @@ extension UIView {
 
 extension MapViewViewController: MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-        let reuseIdentifier = "pin"
         if let parkingSpace = annotation as? ParkingSpaceMapAnnotation {
             print("Parking Space Map Annotation")
+            let reuseIdentifier = parkingSpace.address.street
             var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: reuseIdentifier)
             if annotationView == nil {
                 annotationView = MKAnnotationView(annotation: annotation, reuseIdentifier: reuseIdentifier)


### PR DESCRIPTION
Accounts for more edge cases when converting address string into object. Map view now doesn’t duplicate annotation in same spot.